### PR TITLE
Add prompt to make sure the agent continues to communicate in the cor…

### DIFF
--- a/src/openai.rs
+++ b/src/openai.rs
@@ -58,7 +58,7 @@ impl Conversation {
             name: None,
             role: Role::User,
             content: format!(
-                "OBJECTIVE: {}\nCURRENT URL: {url}\nPAGE CONTENT: {page_content}",
+                "OBJECTIVE: {}\nCURRENT URL: {url}\nPAGE CONTENT: {page_content}. Remember to ONLY respond in the format of CLICK, TYPE, or ANSWER!",
                 self.goal
             ),
         });
@@ -89,6 +89,8 @@ impl Conversation {
             .get(0)
             .ok_or_else(|| anyhow!("No choices returned from OpenAI.",))?
             .message;
+
+        debug!("Message: {}", message.content.clone());
 
         self.messages.push(ChatCompletionRequestMessage {
             name: None,


### PR DESCRIPTION
Once the user prompt gets long enough GPT-4 starts to put less importance on the system message which makes it forget to use the correct format when displaying the result for longer searches. I have found that re-iterating the format in the user message helps with this significantly.