### PR TITLE
Ignore links that containing headings

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -51,6 +51,12 @@ pub async fn translate(elements: &[Element], should_include_p: bool) -> Result<S
                 summary.push(format!("<img id={i} alt=\"{alt_text}\"/>"));
             }
             "A" => {
+                // Do not include links that have headings inside of them. Many websites use this
+                // so that you can link directly to a page section
+                if element.find_elements("h1,h2,h3,h4,h5,h6").await?.len() > 0 {
+                    continue;
+                }
+
                 let Some(inner_text) = inner_text else {
                     continue
                 };


### PR DESCRIPTION
Ignore links containing headings, otherwise the agent tries to click on it and you get an error. Even if it didn't error out it would rarely accomplish anything, usually those links are just section anchors so people can link directly to a section on a page. For example https://platform.openai.com/docs/guides/speech-to-text/quickstart.

Tested on prompt `how to transcribe audio using OPENAI whisper API in linux` with a temperature of 0.2.